### PR TITLE
Add Crossplane Compositions to implement ObjectStorage as an AppCat service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ include Makefile.vars.mk
 -include test/local.mk
 # Crossplane packaging
 -include package/package.mk
+# Crossplane composition
+-include crossplane/composition.mk
 
 .PHONY: help
 help: ## Show this help

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ See all targets with `make help`
 ### QuickStart Demonstration
 
 1. Get an API token cloudscale.ch
-1. `export CLOUDSCALE_API_TOKEN=<the-token>`
-1. `make local-install install-samples`
+2. `export CLOUDSCALE_API_TOKEN=<the-token>`
+3. `make local-install install-samples`
 
 ### Kubernetes Webhook Troubleshooting
 
@@ -69,3 +69,7 @@ To test and troubleshoot the webhooks on the cluster, simply apply your changes 
 ### Crossplane Provider Mechanics
 
 For detailed information on how Crossplane Provider works from a development perspective check [provider mechanics documentation page](https://kb.vshn.ch/app-catalog/explanations/crossplane_provider_mechanics.html). 
+
+## Run Tests for XRD and Composition
+
+Testing of the composition is handled by kuttl. You need it installed on your machine in order to run the tests.

--- a/crossplane/composition.mk
+++ b/crossplane/composition.mk
@@ -1,0 +1,18 @@
+
+.PHONY: crossplane-composition
+crossplane-composition: export KUBECONFIG = $(KIND_KUBECONFIG)
+crossplane-composition: local-install .provider-kubernetes ## Installs the Crossplane compositions in kind cluster
+	kubectl apply -f crossplane/objectbucket/composite.yaml -f crossplane/objectbucket/composition.yaml
+	kubectl create ns provider-cloudscale-secrets --save-config -o yaml --dry-run=client | kubectl apply -f -
+	kubectl label namespace default appuio.io/organization=my-org --overwrite
+
+.PHONY: .provider-kubernetes
+.provider-kubernetes: export KUBECONFIG = $(KIND_KUBECONFIG)
+.provider-kubernetes: crossplane-setup
+	kubectl apply -f crossplane/provider-kubernetes.yaml
+	@kubectl wait --for condition=Healthy provider.pkg.crossplane.io/provider-kubernetes --timeout 60s
+	@kubectl -n crossplane-system wait --for condition=Ready $$(kubectl -n crossplane-system get pods -o name -l pkg.crossplane.io/provider=provider-kubernetes) --timeout 60s
+
+.PHONY: install-samples-composition
+install-samples-composition: crossplane-composition provider-config
+	yq ./crossplane/samples/*.yaml | kubectl apply -f -

--- a/crossplane/objectbucket/composite.yaml
+++ b/crossplane/objectbucket/composite.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xobjectbuckets.appcat.vshn.io
+spec:
+  group: appcat.vshn.io
+  names:
+    kind: XObjectBucket
+    plural: xobjectbuckets
+  claimNames:
+    kind: ObjectBucket
+    plural: objectbuckets
+  connectionSecretKeys:
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+  defaultCompositionRef:
+    name: objectbucket-cloudscale
+  versions:
+    - name: v1
+      referenceable: true
+      served: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - parameters
+              properties:
+                parameters:
+                  type: object
+                  required:
+                    - bucketName
+                    - region
+                  properties:
+                    bucketName:
+                      description: BucketName is the name of the bucket to create. Cannot
+                        be changed after bucket is created. Name must be acceptable by the S3
+                        protocol, which follows RFC 1123. Be aware that S3 providers may require
+                        a unique name across the platform or region.
+                      type: string
+                    region:
+                      description: Region is the name of the region where the bucket shall
+                        be created. The region must be available in the S3 endpoint. Accepted
+                        values are LPG and RMA.
+                      type: string
+                      enum:
+                        - lpg
+                        - rma

--- a/crossplane/objectbucket/composition.yaml
+++ b/crossplane/objectbucket/composition.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: objectbucket-cloudscale
+spec:
+  compositeTypeRef:
+    apiVersion: appcat.vshn.io/v1
+    kind: XObjectBucket
+  writeConnectionSecretsToNamespace: crossplane-system
+  patchSets:
+    - name: annotations
+      patches:
+      - type: FromCompositeFieldPath
+        fromFieldPath: metadata.annotations
+    - name: labels
+      patches:
+      - type: FromCompositeFieldPath
+        fromFieldPath: metadata.labels
+  resources:
+
+    - base:
+        apiVersion: kubernetes.crossplane.io/v1alpha1
+        kind: Object
+        spec:
+          managementPolicy: Observe
+          forProvider:
+            manifest:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: '' # patched
+          providerConfigRef:
+            name: provider-config
+      patches:
+        # set which namespace to observe
+        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+          toFieldPath: spec.forProvider.manifest.metadata.name
+        # copy the appuio organization label to a label on the XR
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.manifest.metadata.labels[appuio.io/organization]
+          toFieldPath: metadata.labels[appuio.io/organization]
+        # append suffix to the observer name
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-ns-observer"
+
+    - base:
+        apiVersion: cloudscale.crossplane.io/v1
+        kind: ObjectsUser
+        metadata:
+          name: ""
+        spec:
+          forProvider:
+            displayName: "" # patched
+            tags:
+              zone: local-dev-kind
+              namespace: # patched
+              tenant: # patched
+          writeConnectionSecretToRef:
+            name: ""
+            namespace: provider-cloudscale-secrets
+          providerConfigRef:
+            name: provider-config
+      connectionDetails:
+        - fromConnectionSecretKey: AWS_ACCESS_KEY_ID
+          type: FromConnectionSecretKey
+          name: AWS_ACCESS_KEY_ID
+        - fromConnectionSecretKey: AWS_SECRET_ACCESS_KEY
+          type: FromConnectionSecretKey
+          name: AWS_SECRET_ACCESS_KEY
+      patches:
+        - type: PatchSet
+          patchSetName: annotations
+        - type: PatchSet
+          patchSetName: labels
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.writeConnectionSecretToRef.name
+        # Set display name
+        - type: CombineFromComposite
+          toFieldPath: spec.forProvider.displayName
+          combine:
+            variables:
+              - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+              - fromFieldPath: metadata.labels[crossplane.io/claim-name]
+            strategy: string
+            string:
+              fmt: "%s.%s"
+        # Set tenant tag
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.labels[appuio.io/organization]
+          toFieldPath: spec.forProvider.tags.tenant
+        # Set namespace tag
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+          toFieldPath: spec.forProvider.tags.namespace
+
+    - base:
+        apiVersion: cloudscale.crossplane.io/v1
+        kind: Bucket
+        metadata:
+          name: ""
+        spec:
+          forProvider:
+            bucketName: ""
+            # Note: We cannot use the connection Secret that is created by Crossplane (it has a name that matches the metadata.uid)
+            # Reason: Upon deleting a claim, the connection secret gets deleted already, without it we can't delete the bucket and we'd be stuck.
+            # That is why we need a duplicate secret that the provider-cloudscale manages (and not crossplane).
+            credentialsSecretRef:
+              name: ""
+              namespace: provider-cloudscale-secrets
+            endpointURL: ""
+            region: ""
+      patches:
+        - type: PatchSet
+          patchSetName: annotations
+        - type: PatchSet
+          patchSetName: labels
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: metadata.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.bucketName
+          toFieldPath: spec.forProvider.bucketName
+        - fromFieldPath: metadata.labels[crossplane.io/composite]
+          toFieldPath: spec.forProvider.credentialsSecretRef.name
+        # Set endpoint
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.endpointURL
+          transforms:
+            - type: string
+              string:
+                fmt: "objects.%s.cloudscale.ch"
+        # Set region
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region

--- a/crossplane/objectbucket/composition.yaml
+++ b/crossplane/objectbucket/composition.yaml
@@ -57,7 +57,6 @@ spec:
           forProvider:
             displayName: "" # patched
             tags:
-              zone: local-dev-kind
               namespace: # patched
               tenant: # patched
           writeConnectionSecretToRef:
@@ -117,6 +116,7 @@ spec:
               namespace: provider-cloudscale-secrets
             endpointURL: ""
             region: ""
+            bucketDeletionPolicy: DeleteIfEmpty
       patches:
         - type: PatchSet
           patchSetName: annotations

--- a/crossplane/provider-kubernetes.yaml
+++ b/crossplane/provider-kubernetes.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  labels:
+    name: provider-kubernetes
+  name: provider-kubernetes
+spec:
+  package: "crossplane/provider-kubernetes:v0.4.0"
+  controllerConfigRef:
+    name: providerconfig-kubernetes
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: provider-config
+spec:
+  credentials:
+    source: InjectedIdentity
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: provider-kubernetes
+  namespace: crossplane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane:provider:provider-kubernetes:system:custom
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+    apiGroups:
+      - kubernetes.crossplane.io
+    resources:
+      - '*'
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+      - coordination.k8s.io
+    resources:
+      - secrets
+      - configmaps
+      - events
+      - leases
+  - verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane:provider:provider-kubernetes:system:custom
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane:provider:provider-kubernetes:system:custom
+subjects:
+- kind: ServiceAccount
+  name: provider-kubernetes
+  namespace: crossplane-system
+---
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: providerconfig-kubernetes
+spec:
+  serviceAccountName: provider-kubernetes

--- a/crossplane/samples/claim.object-bucket.yaml
+++ b/crossplane/samples/claim.object-bucket.yaml
@@ -1,0 +1,11 @@
+apiVersion: appcat.vshn.io/v1
+kind: ObjectBucket
+metadata:
+  name: object-bucket-claim
+  namespace: default
+spec:
+  parameters:
+    bucketName: my-provider-test-bucket-from-claim
+    region: rma
+  writeConnectionSecretToRef:
+    name: credentials

--- a/test/e2e/composition/00-assert.yaml
+++ b/test/e2e/composition/00-assert.yaml
@@ -1,0 +1,59 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+---
+apiVersion: cloudscale.crossplane.io/v1
+kind: ObjectsUser
+metadata:
+  annotations:
+    kuttl: '00-install'
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    displayName: default.bucket
+    tags:
+      namespace: default
+      tenant: my-org
+      zone: local-dev-kind
+  providerConfigRef:
+    name: provider-config
+  writeConnectionSecretToRef:
+    namespace: provider-cloudscale-secrets
+status:
+  atProvider:
+    displayName: default.bucket
+    tags:
+      namespace: default
+      tenant: my-org
+      zone: local-dev-kind
+  conditions:
+    - reason: Available
+      status: 'True'
+      type: Ready
+    - reason: ReconcileSuccess
+      status: 'True'
+      type: Synced
+---
+apiVersion: cloudscale.crossplane.io/v1
+kind: Bucket
+metadata:
+  annotations:
+    kuttl: '00-install'
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    bucketName: my-provider-cloudscale-composition-e2e-test
+    credentialsSecretRef:
+      namespace: provider-cloudscale-secrets
+    endpointURL: objects.rma.cloudscale.ch
+    region: rma
+status:
+  atProvider:
+    bucketName: my-provider-cloudscale-composition-e2e-test
+  conditions:
+    - reason: ReconcileSuccess
+      status: 'True'
+      type: Synced
+    - reason: Available
+      status: 'True'
+      type: Ready

--- a/test/e2e/composition/00-assert.yaml
+++ b/test/e2e/composition/00-assert.yaml
@@ -14,7 +14,6 @@ spec:
     tags:
       namespace: default
       tenant: my-org
-      zone: local-dev-kind
   providerConfigRef:
     name: provider-config
   writeConnectionSecretToRef:
@@ -25,7 +24,6 @@ status:
     tags:
       namespace: default
       tenant: my-org
-      zone: local-dev-kind
   conditions:
     - reason: Available
       status: 'True'

--- a/test/e2e/composition/00-install.yaml
+++ b/test/e2e/composition/00-install.yaml
@@ -1,0 +1,13 @@
+apiVersion: appcat.vshn.io/v1
+kind: ObjectBucket
+metadata:
+  annotations:
+    kuttl: '00-install'
+  name: bucket
+  namespace: default
+spec:
+  parameters:
+    bucketName: my-provider-cloudscale-composition-e2e-test
+    region: rma
+  writeConnectionSecretToRef:
+    name: bucket-credentials-e2e-test

--- a/test/e2e/composition/01-delete.yaml
+++ b/test/e2e/composition/01-delete.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: appcat.vshn.io/v1
+    kind: ObjectBucket
+    name: bucket
+    namespace: default

--- a/test/e2e/composition/01-errors.yaml
+++ b/test/e2e/composition/01-errors.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: cloudscale.crossplane.io/v1
+kind: ObjectsUser
+metadata:
+  annotations:
+    kuttl: '00-install'
+---
+apiVersion: cloudscale.crossplane.io/v1
+kind: Bucket
+metadata:
+  annotations:
+    kuttl: '00-install'

--- a/test/e2e/kuttl-test.yaml
+++ b/test/e2e/kuttl-test.yaml
@@ -4,3 +4,4 @@ testDirs:
   - ./test/e2e
 namespace: default
 timeout: 60 # some tests require more than 30s
+parallel: 1

--- a/test/local.mk
+++ b/test/local.mk
@@ -25,6 +25,7 @@ $(crossplane_sentinel): $(KIND_KUBECONFIG)
 		--set "args[0]='--debug'" \
 		--set "args[1]='--enable-composition-revisions'" \
 		--set webhooks.enabled=true \
+		--set rbacManager.managementPolicy=Basic \
 		--wait
 	@touch $@
 

--- a/test/local.mk
+++ b/test/local.mk
@@ -123,7 +123,7 @@ $(mc_bin): | $(go_bin)
 	go install github.com/minio/mc@latest
 
 test-e2e: export KUBECONFIG = $(KIND_KUBECONFIG)
-test-e2e: $(kuttl_bin) $(mc_bin) local-install provider-config ## E2E tests
+test-e2e: $(kuttl_bin) $(mc_bin) local-install provider-config crossplane-composition ## E2E tests
 	GOBIN=$(go_bin) $(kuttl_bin) test ./test/e2e --config ./test/e2e/kuttl-test.yaml
 	@rm -f kubeconfig
 # kuttle leaves kubeconfig garbage: https://github.com/kudobuilder/kuttl/issues/297


### PR DESCRIPTION
## Summary

This PR adds Crossplane support.

* Added a XRD definition with 2 fields `spec.parameters.bucketName` and `spec.parameters.region`.
* Added a Composition which creates 2 objects: `Bucket` and `ObjectsUser` CRDs.
* Added `provider-kubernetes` which observes the `Namespace` to read and patch the `appuio.io/organization` label
* Added e2e tests with [kuttl](https://kuttl.dev/).

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
