### PR TITLE
Track ProviderConfigs to prevent deletions where they're still being used

### DIFF
--- a/apis/cloudscale/v1/objectsuser_types.go
+++ b/apis/cloudscale/v1/objectsuser_types.go
@@ -76,15 +76,6 @@ func (in *ObjectsUser) GetDisplayName() string {
 	return in.Name
 }
 
-// GetProviderConfigName returns the name of the ProviderConfig.
-// Returns empty string if reference not given.
-func (in *ObjectsUser) GetProviderConfigName() string {
-	if ref := in.GetProviderConfigReference(); ref != nil {
-		return ref.Name
-	}
-	return ""
-}
-
 // +kubebuilder:object:root=true
 
 // ObjectsUserList contains a list of ObjectsUser

--- a/charts/provider-cloudscale/values.yaml
+++ b/charts/provider-cloudscale/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- Operator image registry
   registry: ghcr.io
   # -- Operator image repository
-  repository: vshn/provider-cloudscale
+  repository: vshn/provider-cloudscale/controller
   # -- Operator image pull policy
   # If set to empty, then Kubernetes default behaviour applies.
   pullPolicy: IfNotPresent

--- a/operator/configcontroller/setup.go
+++ b/operator/configcontroller/setup.go
@@ -26,6 +26,7 @@ func SetupController(mgr ctrl.Manager) error {
 
 	of := resource.ProviderConfigKinds{
 		Config:    providerv1.ProviderConfigGroupVersionKind,
+		Usage:     providerv1.ProviderConfigUsageGroupVersionKind,
 		UsageList: providerv1.ProviderConfigUsageListGroupVersionKind,
 	}
 

--- a/test/local.mk
+++ b/test/local.mk
@@ -45,4 +45,4 @@ envtest_crd_dir ?= $(kind_dir)/crds
 .envtest_crds: .envtest_crd_dir
 
 $(kind_dir)/.credentials.yaml:
-	kubectl create secret generic --from-literal CLOUDSCALE_API_TOKEN=$(shell echo $$CLOUDSCALE_API_TOKEN) -o yaml --dry-run=client api-token > $@
+	kubectl create secret generic --from-literal CLOUDSCALE_API_TOKEN=$$CLOUDSCALE_API_TOKEN -o yaml --dry-run=client api-token > $@


### PR DESCRIPTION
## Summary

* This leverages Crossplane's `ProviderConfigUsage` mechanism to track usages of `ProviderConfigs`.

It acts like a finalizer but it's not really documented (https://github.com/crossplane/crossplane/issues/3118), neither is it documented how to use it in a provider: https://crossplane.io/docs/v1.9/contributing/provider_development_guide.html

I figured it out though and now the order of deletions is ensured.

## Checklist


- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] PR contains the label `area:operator`
- [x] Link this PR to related issues
- [x] ~I have not made _any_ changes in the `charts/` directory.~ Only to make it work in this PR, chart is bound to be removed.
