### PR TITLE
Ensure buckets and users are cleanup before deleting cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,6 @@ run-operator: ## Run in Operator mode against your current kube context
 	go run . -v 1 operator
 
 .PHONY: clean
-clean: kind-clean .package-clean .envtest-clean .e2e-test-clean ## Cleans local build artifacts
+clean: .package-clean .envtest-clean .e2e-test-clean kind-clean ## Cleans local build artifacts
 	rm -rf docs/node_modules $(docs_out_dir) dist .cache .work
 	$(DOCKER_CMD) rmi $(CONTAINER_IMG) || true

--- a/test/e2e/provider/01-assert.yaml
+++ b/test/e2e/provider/01-assert.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   deletionPolicy: Delete
   forProvider:
-    bucketName: provider-cloudscale-e2e-test-kuttl
+    bucketName: e2e-test-kuttl-provider-cloudscale
     bucketDeletionPolicy: DeleteAll
     credentialsSecretRef:
       name: objectsuser-credentials-e2e-test-kuttl
@@ -19,7 +19,7 @@ spec:
     region: rma
 status:
   atProvider:
-    bucketName: provider-cloudscale-e2e-test-kuttl
+    bucketName: e2e-test-kuttl-provider-cloudscale
   conditions:
     - type: Ready
       status: 'True'

--- a/test/e2e/provider/01-install-bucket.yaml
+++ b/test/e2e/provider/01-install-bucket.yaml
@@ -7,7 +7,7 @@ metadata:
   name: e2e-test-bucket
 spec:
   forProvider:
-    bucketName: provider-cloudscale-e2e-test-kuttl
+    bucketName: e2e-test-kuttl-provider-cloudscale
     bucketDeletionPolicy: DeleteAll
     credentialsSecretRef:
       name: objectsuser-credentials-e2e-test-kuttl

--- a/test/e2e/provider/02-upload.yaml
+++ b/test/e2e/provider/02-upload.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 commands:
   # note: working dir is the where the yaml files are
   # Args: $endpoint $bucket $file_path $secret_name
-  - command: ../upload-object.sh objects.rma.cloudscale.ch provider-cloudscale-e2e-test-kuttl ../../../README.md objectsuser-credentials-e2e-test-kuttl
+  - command: ../upload-object.sh objects.rma.cloudscale.ch e2e-test-kuttl-provider-cloudscale ../../../README.md objectsuser-credentials-e2e-test-kuttl

--- a/test/local.mk
+++ b/test/local.mk
@@ -125,9 +125,12 @@ $(mc_bin): | $(go_bin)
 test-e2e: export KUBECONFIG = $(KIND_KUBECONFIG)
 test-e2e: $(kuttl_bin) $(mc_bin) local-install provider-config ## E2E tests
 	GOBIN=$(go_bin) $(kuttl_bin) test ./test/e2e --config ./test/e2e/kuttl-test.yaml
+# kuttl leaves kubeconfig garbage: https://github.com/kudobuilder/kuttl/issues/297
 	@rm -f kubeconfig
-# kuttle leaves kubeconfig garbage: https://github.com/kudobuilder/kuttl/issues/297
 
 .PHONY: .e2e-test-clean
+.e2e-test-clean: export KUBECONFIG = $(KIND_KUBECONFIG)
 .e2e-test-clean:
+	if [ -f $(KIND_KUBECONFIG) ]; then kubectl delete buckets --all; else echo "no kubeconfig found"; fi
+	if [ -f $(KIND_KUBECONFIG) ]; then kubectl delete objectsuser --all; else echo "no kubeconfig found"; fi
 	rm -f $(kuttl_bin) $(mc_bin)


### PR DESCRIPTION
## Summary

* Affects local dev and GH actions
* running `make clean` now deletes any leftover buckets if the cluster is running

## Checklist

- [x] PR contains a single logical change (to keep release notes relevant)
- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] Link this PR to related issues
- [x] I have run `make test-e2e` and e2e tests pass successfully
