### PR TITLE
Improve error message if bucket exists already in different region

### DIFF
--- a/operator/bucketcontroller/observe.go
+++ b/operator/bucketcontroller/observe.go
@@ -27,6 +27,9 @@ func (p *ProvisioningPipeline) Observe(ctx context.Context, mg resource.Managed)
 		if errResp.StatusCode == http.StatusForbidden {
 			return managed.ExternalObservation{}, errors.Wrap(err, "wrong credentials or bucket exists already, try changing bucket name")
 		}
+		if errResp.StatusCode == http.StatusMovedPermanently {
+			return managed.ExternalObservation{}, errors.Wrap(err, "mismatching endpointURL and region, or bucket exists already in a different region, try changing bucket name")
+		}
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot determine whether bucket exists")
 	}
 	if exists {


### PR DESCRIPTION


## Summary

Turns out the bucket name has to be unique in the whole cloudscale, not just per region.
* Follow-up of #39 

## Checklist

- [x] PR contains a single logical change (to keep release notes relevant)
- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] Link this PR to related issues
- [x] I have run `make test-e2e` and e2e tests pass successfully
