### PR TITLE
Add "endpoint" field to bucket

### DIFF
--- a/apis/cloudscale/v1/bucket_types.go
+++ b/apis/cloudscale/v1/bucket_types.go
@@ -36,10 +36,8 @@ type BucketParameters struct {
 
 	// +kubebuilder:validation:Required
 
-	// EndpointURL is the URL where to create the bucket.
-	// If the scheme is omitted (`http/s`), HTTPS is assumed.
-	// Changing the endpoint after initial creation might have no effect.
-	EndpointURL string `json:"endpointURL"`
+	// Deprecated: Only here for compatibility with legacy Bucket objects
+	EndpointURL string `json:"endpointURL,omitempty"`
 
 	// BucketName is the name of the bucket to create.
 	// Defaults to `metadata.name` if unset.
@@ -80,6 +78,8 @@ type BucketObservation struct {
 // BucketStatus represents the observed state of a Bucket.
 type BucketStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
+	Endpoint            string            `json:"endpoint,omitempty"`
+	EndpointURL         string            `json:"endpointURL,omitempty"`
 	AtProvider          BucketObservation `json:"atProvider,omitempty"`
 }
 

--- a/generate_sample.go
+++ b/generate_sample.go
@@ -91,7 +91,6 @@ func newBucketSample() *cloudscalev1.Bucket {
 					Name:      "my-cloudscale-user-credentials",
 					Namespace: "default",
 				},
-				EndpointURL:          "objects.rma.cloudscale.ch",
 				BucketName:           "my-provider-test-bucket",
 				Region:               "rma",
 				BucketDeletionPolicy: cloudscalev1.DeleteAll,

--- a/operator/bucketcontroller/connector.go
+++ b/operator/bucketcontroller/connector.go
@@ -33,7 +33,15 @@ type connectContext struct {
 	credentialsSecret *corev1.Secret
 }
 
-// Connect implements managed.ExternalConnecter.
+func getEndpoint(bucket *cloudscalev1.Bucket) string {
+	return fmt.Sprintf("objects.%s.cloudscale.ch", bucket.Spec.ForProvider.Region)
+}
+
+func getEndpointURL(bucket *cloudscalev1.Bucket) string {
+	return fmt.Sprintf("https://%s", getEndpoint(bucket))
+}
+
+// Connect implements managed.ExternalConnector.
 func (c *bucketConnector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
 	ctx = pipeline.MutableContext(ctx)
 	log := controllerruntime.LoggerFrom(ctx)
@@ -103,7 +111,7 @@ func (c *bucketConnector) createS3Client(ctx *connectContext) error {
 	secret := ctx.credentialsSecret
 	bucket := ctx.bucket
 
-	parsed, err := url.Parse(bucket.Spec.ForProvider.EndpointURL)
+	parsed, err := url.Parse(getEndpointURL(bucket))
 	if err != nil {
 		return err
 	}

--- a/operator/bucketcontroller/observe.go
+++ b/operator/bucketcontroller/observe.go
@@ -25,6 +25,9 @@ func (p *ProvisioningPipeline) Observe(ctx context.Context, mg resource.Managed)
 	s3Client := p.minio
 	bucket := fromManaged(mg)
 
+	bucket.Status.Endpoint = getEndpoint(bucket)
+	bucket.Status.EndpointURL = getEndpointURL(bucket)
+
 	bucketName := bucket.GetBucketName()
 	exists, err := bucketExistsFn(ctx, s3Client, bucketName)
 	if err != nil {

--- a/package/crds/cloudscale.crossplane.io_buckets.yaml
+++ b/package/crds/cloudscale.crossplane.io_buckets.yaml
@@ -106,9 +106,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   endpointURL:
-                    description: EndpointURL is the URL where to create the bucket.
-                      If the scheme is omitted (`http/s`), HTTPS is assumed. Changing
-                      the endpoint after initial creation might have no effect.
+                    description: 'Deprecated: Only here for compatibility with legacy
+                      Bucket objects'
                     type: string
                   region:
                     description: Region is the name of the region where the bucket
@@ -117,7 +116,6 @@ spec:
                     type: string
                 required:
                 - credentialsSecretRef
-                - endpointURL
                 - region
                 type: object
               providerConfigRef:
@@ -334,6 +332,10 @@ spec:
                   - type
                   type: object
                 type: array
+              endpoint:
+                type: string
+              endpointURL:
+                type: string
             type: object
         required:
         - spec

--- a/samples/admission.k8s.io_admissionreview.json
+++ b/samples/admission.k8s.io_admissionreview.json
@@ -44,7 +44,6 @@
             "name": "my-cloudscale-user-credentials",
             "namespace": "default"
           },
-          "endpointURL": "objects.rma.cloudscale.ch",
           "bucketName": "another",
           "region": "rma",
           "bucketDeletionPolicy": "DeleteAll"
@@ -67,7 +66,6 @@
             "name": "my-cloudscale-user-credentials",
             "namespace": "default"
           },
-          "endpointURL": "objects.rma.cloudscale.ch",
           "bucketName": "my-provider-test-bucket",
           "region": "rma",
           "bucketDeletionPolicy": "DeleteAll"

--- a/samples/cloudscale.crossplane.io_bucket.yaml
+++ b/samples/cloudscale.crossplane.io_bucket.yaml
@@ -10,7 +10,6 @@ spec:
     credentialsSecretRef:
       name: my-cloudscale-user-credentials
       namespace: default
-    endpointURL: objects.rma.cloudscale.ch
     region: rma
 status:
   atProvider: {}

--- a/test/e2e/provider/01-assert.yaml
+++ b/test/e2e/provider/01-assert.yaml
@@ -16,7 +16,6 @@ spec:
     credentialsSecretRef:
       name: objectsuser-credentials-e2e-test-kuttl
       namespace: default
-    endpointURL: objects.rma.cloudscale.ch
     region: rma
 status:
   atProvider:
@@ -28,4 +27,6 @@ status:
     - type: Synced
       status: 'True'
       reason: ReconcileSuccess
+  endpoint: objects.rma.cloudscale.ch
+  endpointURL: https://objects.rma.cloudscale.ch
 ---

--- a/test/e2e/provider/01-install-bucket.yaml
+++ b/test/e2e/provider/01-install-bucket.yaml
@@ -12,6 +12,5 @@ spec:
     credentialsSecretRef:
       name: objectsuser-credentials-e2e-test-kuttl
       namespace: default
-    endpointURL: objects.rma.cloudscale.ch
     region: rma
 ---


### PR DESCRIPTION
Due to apparent limitations of Crossplane compositions we need both an "endpoint" and an "endpointURL" field. "endpoint" will contain the simple endpoint host name, while endpointURL will contain the full URL (https://...).

Context: https://ticket.vshn.net/browse/APPCAT-226