### PR TITLE
Release crossplane package to upbound market

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Login to Upbound
+        uses: docker/login-action@v1
+        with:
+          registry: xpkg.upbound.io
+          username: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
+          password: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
+
       - name: Login to ghcr.io
         uses: docker/login-action@v2
         with:

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -16,11 +16,13 @@ DOCKER_CMD ?= docker
 
 IMG_TAG ?= latest
 CONTAINER_REGISTRY ?= ghcr.io
+UPBOUND_CONTAINER_REGISTRY ?= xpkg.upbound.io
+
 # Image URL to use all building/pushing image targets
 CONTAINER_IMG ?= $(CONTAINER_REGISTRY)/$(PROJECT_OWNER)/$(PROJECT_NAME)/controller:$(IMG_TAG)
-# Image URL for the package image.
-# Not documented "feature" of GitHub container registry: Don't name your image "package", otherwise you'll get "forbidden" error messages
-PACKAGE_IMG ?= $(CONTAINER_REGISTRY)/$(PROJECT_OWNER)/$(PROJECT_NAME)/provider:$(IMG_TAG)
+LOCAL_PACKAGE_IMG = localhost:5000/$(PROJECT_OWNER)/$(PROJECT_NAME)/package:$(IMG_TAG)
+GHCR_PACKAGE_IMG ?= $(CONTAINER_REGISTRY)/$(PROJECT_OWNER)/$(PROJECT_NAME)/provider:$(IMG_TAG)
+UPBOUND_PACKAGE_IMG ?= $(UPBOUND_CONTAINER_REGISTRY)/$(PROJECT_OWNER)/$(PROJECT_NAME):$(IMG_TAG)
 
 ## KIND:setup
 

--- a/package/crossplane.yaml.template
+++ b/package/crossplane.yaml.template
@@ -3,11 +3,18 @@ kind: Provider
 metadata:
   name: provider-cloudscale
   annotations:
-    meta.crossplane.io/maintainer: VSHN <info@vshn.net>
+    meta.crossplane.io/maintainer: VSHN <info@vshn.ch>
     meta.crossplane.io/source: github.com/vshn/provider-cloudscale
     meta.crossplane.io/license: Apache-2
     meta.crossplane.io/description: |
-      Crossplane provider for managing resources on cloudscale.ch
+      VSHN's Crossplane provider to manage cloudscale.ch services in Kubernetes.
+    meta.crossplane.io/readme: |
+      `provider-cloudscale` is the Crossplane infrastructure provider for
+      [cloudscale.ch](https://www.cloudscale.ch/), provided by [VSHN](https://www.vshn.ch/).
+      Available resources and their fields can be found in the
+      [CRD Docs](https://marketplace.upbound.io/providers/vshn/provider-cloudscale/latest/crds).
+      If you encounter an issue please create an issue in the
+      [vshn/provider-cloudscale](https://github.com/vshn/provider-cloudscale/issues) repo.
 spec:
   controller:
     image: ghcr.io/vshn/provider-cloudscale/controller:latest

--- a/package/package.mk
+++ b/package/package.mk
@@ -3,6 +3,7 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 package_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
 
 crossplane_bin = $(go_bin)/kubectl-crossplane
+up_bin = $(go_bin)/up
 
 # Build kubectl-crossplane plugin
 $(crossplane_bin):export GOBIN = $(go_bin)
@@ -10,23 +11,50 @@ $(crossplane_bin): | $(go_bin)
 	go install github.com/crossplane/crossplane/cmd/crank@latest
 	@mv $(go_bin)/crank $@
 
+# Install up plugin
+$(up_bin):export GOBIN = $(go_bin)
+$(up_bin): | $(go_bin)
+	curl -sL "https://cli.upbound.io" | sh
+	@mv up $@
+
 .PHONY: package
 package: ## All-in-one packaging and releasing
 package: package-push
 
-.PHONY: package-provider
-package-provider: export CONTROLLER_IMG = $(CONTAINER_IMG)
-package-provider: $(crossplane_bin) generate-go ## Build Crossplane package
+.PHONY: package-provider-local
+package-provider-local: export CONTROLLER_IMG = $(CONTAINER_IMG)
+package-provider-local: $(crossplane_bin) generate-go ## Build Crossplane package for local installation in kind-cluster
 	@rm -rf package/*.xpkg
 	@yq e '.spec.controller.image=strenv(CONTROLLER_IMG)' $(package_dir)/crossplane.yaml.template > $(package_dir)/crossplane.yaml
 	@$(crossplane_bin) build provider -f $(package_dir)
 	@echo Package file: $$(ls $(package_dir)/*.xpkg)
 
+.PHONY: package-provider
+package-provider: export CONTROLLER_IMG = $(CONTAINER_IMG)
+package-provider: $(up_bin) generate-go build-docker ## Build Crossplane package for Upbound Marketplace
+	@rm -rf package/*.xpkg
+	@yq e 'del(.spec)' $(package_dir)/crossplane.yaml.template > $(package_dir)/crossplane.yaml
+	$(up_bin) xpkg build -f $(package_dir) -o $(package_dir)/provider-cloudscale.xpkg --controller=$(CONTROLLER_IMG)
+
+.PHONY: .local-package-push
+.local-package-push: pkg_file = $(shell ls $(package_dir)/*.xpkg)
+.local-package-push: $(crossplane_bin) package-provider-local
+	$(crossplane_bin) push provider -f $(pkg_file) $(LOCAL_PACKAGE_IMG)
+
+.PHONY: .ghcr-package-push
+.ghcr-package-push: pkg_file = $(package_dir)/provider-cloudscale.xpkg
+.ghcr-package-push: $(crossplane_bin) package-provider
+	$(crossplane_bin) push provider -f $(pkg_file) $(GHCR_PACKAGE_IMG)
+
+.PHONY: .upbound-package-push
+.upbound-package-push: pkg_file = $(package_dir)/provider-cloudscale.xpkg
+.upbound-package-push: package-provider
+	$(up_bin) xpkg push -f $(pkg_file) $(UPBOUND_PACKAGE_IMG)
+
 .PHONY: package-push
-package-push: pkg_file = $(shell ls $(package_dir)/*.xpkg)
-package-push: package-provider ## Push Crossplane package to container registry
-	$(crossplane_bin) push provider -f $(pkg_file) $(PACKAGE_IMG)
+package-push: pkg_file = $(package_dir)/provider-cloudscale.xpkg
+package-push: .ghcr-package-push .upbound-package-push ## Push Crossplane package to container registry
 
 .PHONY: .package-clean
 .package-clean:
-	rm -f $(crossplane_bin) package/*.xpkg $(package_dir)/crossplane.yaml
+	rm -f $(crossplane_bin) $(up_bin) package/*.xpkg $(package_dir)/crossplane.yaml

--- a/test/local.mk
+++ b/test/local.mk
@@ -5,9 +5,7 @@ registry_sentinel = $(kind_dir)/registry_sentinel
 local-install: export KUBECONFIG = $(KIND_KUBECONFIG)
 # for ControllerConfig:
 local-install: export INTERNAL_PACKAGE_IMG = registry.registry-system.svc.cluster.local:5000/$(PROJECT_OWNER)/$(PROJECT_NAME)/package:$(IMG_TAG)
-# for package-push:
-local-install: PACKAGE_IMG = localhost:5000/$(PROJECT_OWNER)/$(PROJECT_NAME)/package:$(IMG_TAG)
-local-install: kind-load-image crossplane-setup registry-setup package-push  ## Install Operator in local cluster
+local-install: kind-load-image crossplane-setup registry-setup .local-package-push  ## Install Operator in local cluster
 	yq e '.spec.metadata.annotations."local.dev/installed"="$(shell date)"' test/controllerconfig-cloudscale.yaml | kubectl apply -f -
 	yq e '.spec.package=strenv(INTERNAL_PACKAGE_IMG)' test/provider-cloudscale.yaml | kubectl apply -f -
 	kubectl wait --for condition=Healthy provider.pkg.crossplane.io/provider-cloudscale --timeout 60s


### PR DESCRIPTION
## Summary

* Release crossplane package to [upbound market](https://marketplace.upbound.io/).
* The `build` operation of package image has changed, meanwhile the `push` is done to both upbound market and the ghcr repository.

This PR will not be merged until a newer version (current v0.14.0) of [up CLI](https://github.com/upbound/up) is available which will add support for [webhook configuration](https://github.com/upbound/up/issues/270).

Update:
* The package image is still rejected on the upbound marketplace. Crossplane support is looking into it. I will update the source code in case there will be changes required by Crossplane.

Update 2:
* Upbound released a [new](https://github.com/upbound/up/releases/tag/v0.15.0) version of its CLI that allows webhook configuration in their xpkg.
* Test the release process with [act](https://github.com/nektos/act) on local machine. 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
