### PR TITLE
Extend PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,26 @@
-## Summary
 
-* Short summary of what's included in the PR
-* Give special note to breaking changes: List the exact changes or provide links to documentation.
+
 
 ## Checklist
 
-- [ ] PR contains a single logical change (to keep release notes relevant)
-- [ ] Categorize the PR by setting a good title and adding one of the labels:
-  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
-  as they show up in the changelog
-- [ ] Link this PR to related issues
-- [ ] I have run `make test-e2e` and e2e tests pass successfully
+- [ ] The PR has a meaningful title. It will be used to auto generate the
+      changelog.
+      The PR has a meaningful description that sums up the change. It will be
+      linked in the changelog.
+- [ ] PR contains a single logical change (to build a better changelog).
+- [ ] Update the documentation.
+- [ ] Categorize the PR by adding one of the labels:
+      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
+      as they show up in the changelog.
+- [ ] Link this PR to related issues or PRs.
+
+<!--
+Thank you for your pull request. Please provide a description above and
+review the checklist.
+
+Contributors guide: ./CONTRIBUTING.md
+
+Remove items that do not apply. For completed items, change [ ] to [x].
+These things are not required to open a PR and can be done afterwards,
+while the PR is open.
+-->


### PR DESCRIPTION
This will adjust the checklist in the PR template to contain more context and expectations how a PR should be presented before it's review ready.

As discussed in https://github.com/vshn/component-appcat/pull/77

## Checklist

- [x] PR contains a single logical change (to keep release notes relevant)
- [x] Categorize the PR by setting a good title and adding one of the labels:
  `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
  as they show up in the changelog
- [x] Link this PR to related issues
- [x] I have run `make test-e2e` and e2e tests pass successfully
