### PR TITLE
Revert required flag for endpointURL

### DIFF
--- a/apis/cloudscale/v1/bucket_types.go
+++ b/apis/cloudscale/v1/bucket_types.go
@@ -34,8 +34,6 @@ type BucketParameters struct {
 	// The secret must contain the keys `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 	CredentialsSecretRef corev1.SecretReference `json:"credentialsSecretRef"`
 
-	// +kubebuilder:validation:Required
-
 	// Deprecated: Only here for compatibility with legacy Bucket objects
 	EndpointURL string `json:"endpointURL,omitempty"`
 

--- a/package/crds/cloudscale.crossplane.io_buckets.yaml
+++ b/package/crds/cloudscale.crossplane.io_buckets.yaml
@@ -127,7 +127,6 @@ spec:
                     type: string
                 required:
                 - credentialsSecretRef
-                - endpointURL
                 - region
                 type: object
               managementPolicies:


### PR DESCRIPTION
Looks like some bug was fixed in the kubebuilder generator as this required flag hasn't been set before.

All the logic in our compositions assume that this value is not required. Which leads to broken instances.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
