### PR TITLE
Fix early cr bucket deletion

### DIFF
--- a/operator/bucketcontroller/delete.go
+++ b/operator/bucketcontroller/delete.go
@@ -40,18 +40,18 @@ func hasDeleteAllPolicy(ctx *pipelineContext) bool {
 }
 
 func (p *ProvisioningPipeline) deleteAllObjects(ctx *pipelineContext) error {
-	log := controllerruntime.LoggerFrom(ctx)
 	bucketName := ctx.bucket.Status.AtProvider.BucketName
 
 	objectsCh := make(chan minio.ObjectInfo)
+	var listObjectErr error
 
 	// Send object names that are needed to be removed to objectsCh
 	go func() {
 		defer close(objectsCh)
 		for object := range p.minio.ListObjects(ctx, bucketName, minio.ListObjectsOptions{Recursive: true}) {
 			if object.Err != nil {
-				log.V(1).Info("warning: cannot list object", "key", object.Key, "error", object.Err)
-				continue
+				listObjectErr = object.Err
+				return
 			}
 			objectsCh <- object
 		}
@@ -59,6 +59,10 @@ func (p *ProvisioningPipeline) deleteAllObjects(ctx *pipelineContext) error {
 
 	for obj := range p.minio.RemoveObjects(ctx, bucketName, objectsCh, minio.RemoveObjectsOptions{GovernanceBypass: true}) {
 		return fmt.Errorf("object %q cannot be removed: %w", obj.ObjectName, obj.Err)
+	}
+
+	if listObjectErr != nil {
+		return fmt.Errorf("cannot list objects for deletion: %w", listObjectErr)
 	}
 	return nil
 }

--- a/operator/objectsusercontroller/observe.go
+++ b/operator/objectsusercontroller/observe.go
@@ -47,6 +47,12 @@ func (p *ObjectsUserPipeline) Observe(ctx context.Context, mg resource.Managed) 
 		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false, ConnectionDetails: toConnectionDetails(csUser)}, nil
 	}
 
+	// Skip credentials reconciliation during deletion — credentials are irrelevant
+	// for the delete path and their secret may already be gone.
+	if !user.GetDeletionTimestamp().IsZero() {
+		return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ConnectionDetails: toConnectionDetails(csUser)}, nil
+	}
+
 	pipe := pipeline.NewPipeline[*pipelineContext]()
 	result := pipe.WithBeforeHooks(pipelineutil.DebugLogger(pctx)).WithSteps(
 		pipe.WithNestedSteps("observe credentials secret", hasSecretRef,
@@ -103,7 +109,7 @@ func (p *ObjectsUserPipeline) checkCredentials(ctx *pipelineContext) error {
 
 func (p *ObjectsUserPipeline) observeCredentialsHandler(ctx *pipelineContext, err error) error {
 	log := controllerruntime.LoggerFrom(ctx)
-	log.V(1).Error(err, "Credentials Secret needs reconciling")
+	log.V(1).Info("Credentials Secret needs reconciling", "error", err)
 	return nil
 }
 


### PR DESCRIPTION
  Bug 1 — ObjectsUser stuck during deletion (objectsusercontroller/observe.go)

When the ObjectsUser CR has a deletion timestamp, Observe() still runs the full credentials reconciliation pipeline. If the credentials secret is already gone (it may have been cleaned up earlier in the deletion sequence), the pipeline logs Credentials Secret needs reconciling and returns ResourceUpToDate: false. This causes Crossplane to call Update() instead of Delete() on the ObjectsUser, which also fails. The ObjectsUser is stuck in this loop and its S3 user account is never deleted cleanly, which can leave the bucket controller without valid credentials on retry.

  Bug 2 — Silent listing failure in deleteAllObjects (bucketcontroller/delete.go)

deleteAllObjects streams objects from ListObjects into a goroutine and pipes them to RemoveObjects. If ListObjects returns an error mid-stream (e.g. auth failure, network issue), the original code did continue, silently ignoring the error. The channel closes with a partial object list, RemoveObjects deletes only those objects, and deleteAllObjects returns nil — a false success. The pipeline then calls deleteS3Bucket on a bucket that still contains objects.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
